### PR TITLE
Switch to new lambda provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+# Usage: make
+# make ARCH=arm64
+
+ARCH ?= x86_64
+
+ifeq ($(ARCH),arm64)
+BOOTSTRAP ?= bootstrap_arm64.zip
+else
+BOOTSTRAP ?= bootstrap.zip
+endif
+
+all: run
+
+run: start-localstack wait-localstack create-function wait-function-active invoke
+
+start-localstack:
+	docker compose down && docker compose up -d
+
+wait-localstack:
+	@echo -n Waiting for LocalStack startup
+	@until curl -sfo /dev/null localhost:4566/_localstack/health; do echo ".\c"; sleep 1; done
+	@echo
+	@echo LocalStack is up and running
+
+create-function:
+	aws --endpoint http://localhost:4566 lambda create-function \
+    --function-name test \
+    --zip-file fileb://$$PWD/$(BOOTSTRAP) \
+    --handler "bootstrap" \
+    --runtime "provided.al2" \
+    --role arn:aws:iam::000000000000:role/lambda-ex \
+    --no-cli-pager \
+    --region us-east-1 \
+	--architectures $(ARCH)
+
+wait-function-active:
+	# Wait until function transitioned from Pending to Active state.
+	# See https://aws.amazon.com/blogs/compute/coming-soon-expansion-of-aws-lambda-states-to-all-functions/
+	aws --endpoint http://localhost:4566 lambda wait function-active-v2 \
+		--function-name test
+
+invoke:
+	aws --endpoint http://localhost:4566 lambda invoke \
+    --function-name test \
+    --cli-binary-format raw-in-base64-out \
+    --payload '{"test": true}' \
+    --no-cli-pager \
+    output.json
+
+stop:
+	docker compose down
+
+.PHONY: run start-localstack wait-localstack create-function create-function-arm wait-function-active invoke stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - LAMBDA_REMOVE_CONTAINERS=true
       - LOCALSTACK_API_KEY=${LOCALSTACK_API_KEY- }  # only required for Pro
       - DOCKER_HOST=unix:///var/run/docker.sock
+      - PROVIDER_OVERRIDE_LAMBDA=v2
     volumes:
       - "${TMPDIR:-/tmp}/localstack:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,11 @@ aws --endpoint http://localhost:4566 lambda create-function \
     --no-cli-pager \
     --region us-east-1
 
+# Wait until function transitioned from Pending to Active state.
+# See https://aws.amazon.com/blogs/compute/coming-soon-expansion-of-aws-lambda-states-to-all-functions/
+aws --endpoint http://localhost:4566 lambda wait function-active-v2 \
+    --function-name test
+
 aws --endpoint http://localhost:4566 lambda invoke \
     --function-name test \
     --cli-binary-format raw-in-base64-out \


### PR DESCRIPTION
Hi @fermanjj 

Adopting our new lambda provider implementation through `PROVIDER_OVERRIDE_LAMBDA=v2` adds support for ARM lambdas.
The new provider will also come with some [behavioral changes](https://docs.localstack.cloud/references/lambda-asf-provider/). Most notably, it will behave much closer to AWS.

✅ `make ARCH=arm64` succeeds using the arm64 binary
❎ `make` currently fails with a runtime error `Runtime exited with error: signal: illegal instruction` (visible in the Docker logs of the lambda function)

This is likely related to Rust compilation for emulated qemu (e.g., when running `x86_64` on ARM Macs). Setting the Rust target to `RUST_TARGET ?= x86_64-unknown-linux-musl` should work as demonstrated in one of our integration tests [here](https://github.com/localstack/localstack/blob/master/tests/integration/awslambda/functions/common/endpointinjection/provided/Makefile#L20).
